### PR TITLE
[fux] fix mc_kl_divergence()

### DIFF
--- a/src/distribution_extension/kl.py
+++ b/src/distribution_extension/kl.py
@@ -77,8 +77,8 @@ def mc_kl_divergence(
         KL divergence.
 
     """
-    p_samples = p.rsample(torch.Size([num_samples]))
-    return q.log_prob(p_samples).mean() - p.log_prob(p_samples).mean()
+    q_samples = q.rsample(torch.Size([num_samples]))
+    return q.log_prob(q_samples).mean() - p.log_prob(q_samples).mean()
 
 
 def gmm_loss(gmm: GMM, normal: Normal) -> Tensor:


### PR DESCRIPTION
- mc_kl_divergence()のサンプリングについて、pの分布からサンプリングを使用していたが、qの分布からサンプリングを使用するように修正した。
- たった2行だけなんで、このプルリクを下げて、nomtinさんが自分で修正しても大丈夫です。